### PR TITLE
Add clear all

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -806,8 +806,9 @@ class InstanceBackend(object):
         raise InvalidInstanceIdError(instance_id)
 
     def release_resources(self):
-        subprocess.run('bash {}/clear_all.sh' \
-            .format(settings.VM_SCRIPT_DIR), shell=True)
+        if settings.RUN_AS_VM:
+            subprocess.run('bash {}/clear_all.sh' \
+                .format(settings.VM_SCRIPT_DIR), shell=True)
 
     def add_instances(self, image_id, count, user_data, security_group_names,
                       **kwargs):

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -503,14 +503,6 @@ class Instance(TaggedEC2Resource, BotoInstance):
             associate_public_ip=associate_public_ip
         )
 
-    def release_resources(self):
-        if self._state.name == 'running':
-            self.terminate()
-
-        if settings.RUN_AS_VM:
-            subprocess.run("bash {}/delete_instance.sh instance_{}"
-                           .format(settings.VM_SCRIPT_DIR, self.id), shell=True)
-
     def __del__(self):
         try:
             subnet = self.ec2_backend.get_subnet(self.subnet_id)
@@ -814,9 +806,8 @@ class InstanceBackend(object):
         raise InvalidInstanceIdError(instance_id)
 
     def release_resources(self):
-        for r in self.reservations.values():
-            for i in r.instances:
-                i.release_resources()
+        subprocess.run('bash {}/clear_all.sh' \
+            .format(settings.VM_SCRIPT_DIR), shell=True)
 
     def add_instances(self, image_id, count, user_data, security_group_names,
                       **kwargs):

--- a/moto/vm_scripts/clear_all.sh
+++ b/moto/vm_scripts/clear_all.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+(IFS='
+'
+
+for instance in $(vboxmanage list vms); do
+    name=$(echo $instance | sed -E 's/"(.+)".*/\1/')
+
+    if [ $name == 'base' ]; then
+        continue
+    fi
+
+    $($DIR/stop_instance.sh $name)
+    $($DIR/delete_instance.sh $name)
+done)


### PR DESCRIPTION
This PR adds a more robust way to clear all vm instances. Moto will now use `clear_all.sh` that works directly with VirtualBox.